### PR TITLE
add license blurb to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ If you have Sawmill installed as a submodule, you can update it with the followi
 ```bash
 git submodule update --remote --merge
 ```
+
+### License
+
+This theme is released under the MIT license. For more information read the [License](https://github.com/dwalkr/sawmill/blob/master/LICENSE.md).


### PR DESCRIPTION
Hi DJ,

I just added a license blurb on the Readme.md since I saw it on an official [Hugo theme](https://github.com/dt801ts/sublime-hugo-theme) that way and it was mentioned in a Github issue to make it as clear as possible to see what licensing is used.