### PR TITLE
Update bulma minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "autoprefixer": "^8.3.0",
-    "bulma": "^0.7.0",
+    "bulma": "^0.7.1",
     "css-loader": "^0.28.11",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass": "^4.8.3",


### PR DESCRIPTION
bump to 0.7.1 which includes the following changes =>
Add all shades to has-background-* helpers
Remove navbar box-shadow by default